### PR TITLE
Compiler warnings + CMakeList fix

### DIFF
--- a/include/pgm_index.hpp
+++ b/include/pgm_index.hpp
@@ -514,9 +514,9 @@ template<typename K, size_t Error,
 class PGMIndex : public IndexingStrategy {
     using segmentation_type = Segmentation<K, Error, Floating>;
 
+    size_t data_size; ///< The number of elements in the data.
     K first;          ///< The smallest element in the data.
     K last;           ///< The largest element in the data.
-    size_t data_size; ///< The number of elements in the data.
 
 public:
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp ${CMAKE_SOURCE_DIR}/lib/catch.hpp)
+add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../lib/catch.hpp)
 target_link_libraries(tests pgmindexlib)


### PR DESCRIPTION
Hi,

Two simple changes to:
1. Avoid a GCC initalizer reordering warning
2. Allow the tests to be built and ran when PGM index is included as a subdirectory in another CMake project