### PR TITLE
Bucket pgm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: |
           if [[ "${{ matrix.compiler }}" == "gcc" ]]; then
-            export CC=gcc-8 CXX=g++-8
+            export CC=gcc CXX=g++
           else
             export CC=clang CXX=clang++
           fi

--- a/include/pgm/pgm_index_variants.hpp
+++ b/include/pgm/pgm_index_variants.hpp
@@ -395,8 +395,7 @@ protected:
                     " is too low. Try to set it to " + std::to_string(TopLevelBitSize << 1));
             top_level = sdsl::int_vector<TopLevelBitSize>(top_level_size, segments.size(), TopLevelBitSize);
         }
-
-        step = CEIL_INT_DIV(*std::prev(last), top_level_size);
+        step = std::max<K>(CEIL_INT_DIV(*std::prev(last), top_level_size), K(1));
         for (auto i = 0ull, k = 1ull; i < top_level_size - 1; ++i) {
             while (k < segments.size() && (segments[k].key - first_key) < K(i + 1) * step)
                 ++k;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -106,6 +106,14 @@ TEMPLATE_TEST_CASE_SIG("Bucketing PGM-index", "", ((size_t E), E), 8, 32, 128) {
     test_index(index, data);
 }
 
+TEMPLATE_TEST_CASE_SIG("Bucketing PGM-index simple", "", ((size_t E), E), 8, 32, 128) {
+  auto data = std::vector<uint32_t>();
+  data.resize(3000000);
+  auto top_level_size = GENERATE(256, 1024, 4096);
+  pgm::BucketingPGMIndex<uint32_t, E> index(data.begin(), data.end(), top_level_size);
+  test_index(index, data);
+}
+
 TEMPLATE_TEST_CASE_SIG("Elias-Fano PGM-index", "", ((size_t E), E), 8, 32, 128) {
     auto data = generate_data<uint32_t>(3000000);
     pgm::EliasFanoPGMIndex<uint32_t, E> index(data.begin(), data.end());


### PR DESCRIPTION
During performance testing, an error occurred with division by 0 when there are only identical elements in the structure. As far as we understand, this can be fixed quite simply. We also added a test for this case.