### PR TITLE
Implementation of a one-level PGM based on the Eytzinger array

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: |
           if [[ "${{ matrix.compiler }}" == "gcc" ]]; then
-            export CC=gcc-8 CXX=g++-8
+            export CC=gcc CXX=g++
           else
             export CC=clang CXX=clang++
           fi

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -16,6 +16,7 @@
 #include "benchmark.hpp"
 #include "args.hxx"
 #include "pgm/pgm_index.hpp"
+#include "pgm/pgm_index_eytzinger.hpp"
 #include "pgm/pgm_index_variants.hpp"
 
 #include <fstream>
@@ -25,12 +26,17 @@
 #define FOR_EACH_EPSILON(C, K) C<K, 8>, C<K, 16>, C<K, 32>, C<K, 64>, C<K, 128>, C<K, 256>, \
                                C<K, 512>, C<K, 1024>, C<K, 2048>, C<K, 4096>
 
+#define FOR_EACH_EPSILON_ONE_LEVEL(C, K) C<K, 8, 0>, C<K, 16, 0>, C<K, 32, 0>, C<K, 64, 0>, C<K, 128, 0>, C<K, 256, 0>, \
+                               C<K, 512, 0>, C<K, 1024, 0>, C<K, 2048, 0>, C<K, 4096, 0>
+
 #define PGM_CLASSES(K) FOR_EACH_EPSILON(pgm::PGMIndex, K)
+#define PGM_CLASSES(K) FOR_EACH_EPSILON_ONE_LEVEL(pgm::PGMIndex, K)
+#define EYPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::PGMIndexEytzinger, K)
 #define BPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::BucketingPGMIndex, K)
 #define EFPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::EliasFanoPGMIndex, K)
 #define CPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::CompressedPGMIndex, K)
 
-#define ALL_CLASSES(K) PGM_CLASSES(K), BPGM_CLASSES(K), EFPGM_CLASSES(K), CPGM_CLASSES(K)
+#define ALL_CLASSES(K) PGM_CLASSES(K), EYPGM_CLASSES(K), BPGM_CLASSES(K), EFPGM_CLASSES(K), CPGM_CLASSES(K)
 
 template<typename K>
 void read_ints_helper(args::PositionalList<std::string> &files,

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -26,17 +26,15 @@
 #define FOR_EACH_EPSILON(C, K) C<K, 8>, C<K, 16>, C<K, 32>, C<K, 64>, C<K, 128>, C<K, 256>, \
                                C<K, 512>, C<K, 1024>, C<K, 2048>, C<K, 4096>
 
-#define FOR_EACH_EPSILON_ONE_LEVEL(C, K) C<K, 8, 0>, C<K, 16, 0>, C<K, 32, 0>, C<K, 64, 0>, C<K, 128, 0>, C<K, 256, 0>, \
-                               C<K, 512, 0>, C<K, 1024, 0>, C<K, 2048, 0>, C<K, 4096, 0>
-
 #define PGM_CLASSES(K) FOR_EACH_EPSILON(pgm::PGMIndex, K)
-#define PGM_CLASSES(K) FOR_EACH_EPSILON_ONE_LEVEL(pgm::PGMIndex, K)
+#define PGM_CLASSES_ZERO(K) FOR_EACH_EPSILON(pgm::OneLevelPGMIndex, K)
 #define EYPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::PGMIndexEytzinger, K)
 #define BPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::BucketingPGMIndex, K)
+#define BEYPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::BucketingPGMIndexEytzinger, K)
 #define EFPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::EliasFanoPGMIndex, K)
 #define CPGM_CLASSES(K) FOR_EACH_EPSILON(pgm::CompressedPGMIndex, K)
 
-#define ALL_CLASSES(K) PGM_CLASSES(K), EYPGM_CLASSES(K), BPGM_CLASSES(K), EFPGM_CLASSES(K), CPGM_CLASSES(K)
+#define ALL_CLASSES(K) PGM_CLASSES(K), PGM_CLASSES_ZERO(K), EYPGM_CLASSES(K), BPGM_CLASSES(K), BEYPGM_CLASSES(K), EFPGM_CLASSES(K), CPGM_CLASSES(K)
 
 template<typename K>
 void read_ints_helper(args::PositionalList<std::string> &files,

--- a/include/pgm/eytzinger_array.hpp
+++ b/include/pgm/eytzinger_array.hpp
@@ -1,0 +1,104 @@
+//
+// Created by Роман Агеев on 4/12/21.
+//
+
+#ifndef PIECEWISEGEOMETRICMODELINDEX_EYTZINGER_ARRAY_HPP
+#define PIECEWISEGEOMETRICMODELINDEX_EYTZINGER_ARRAY_HPP
+#include <iostream>
+#include <algorithm>
+
+template<typename T>
+class EytzingerArray {
+  static const size_t multiplier = 64 / sizeof(T);
+  static const size_t offset = multiplier + (multiplier >> 1);
+
+  T* array = nullptr;
+  size_t _size = 0;
+  template<typename ForwardIterator>
+  ForwardIterator reorder_data(ForwardIterator iter, size_t pos);
+
+ public:
+  EytzingerArray() = default;
+
+  EytzingerArray(EytzingerArray const &other) : EytzingerArray() {
+    auto copy = EytzingerArray(other.array, _size);
+    swap(copy);
+  }
+
+  EytzingerArray &operator=(EytzingerArray const &other) {
+    auto copy = EytzingerArray(other.array, _size);
+    swap(copy);
+    return *this;
+  }
+
+  EytzingerArray(EytzingerArray &&other) noexcept : EytzingerArray()  {
+    swap(other);
+  }
+
+  EytzingerArray &operator=(EytzingerArray &&other) noexcept {
+    swap(other);
+    return *this;
+  }
+  ~EytzingerArray();
+
+  size_t size() const {
+    return _size;
+  }
+
+  template<typename ForwardIterator>
+  EytzingerArray(ForwardIterator iter, size_t size);
+
+  T & operator[](size_t idx) {
+    return array[idx];
+  }
+
+  T const & operator[](size_t idx) const {
+    return array[idx];
+  }
+
+  template<bool prefetch = true>
+  size_t search(T x) const;
+
+  void swap(EytzingerArray & other) noexcept {
+    std::swap(array, other.array);
+    std::swap(_size, other._size);
+  }
+};
+
+template<typename T>
+template<typename ForwardIterator>
+ForwardIterator EytzingerArray<T>::reorder_data(ForwardIterator iter, size_t pos) {
+  if (pos < _size) {
+    iter = reorder_data(iter, (pos << 1u) + 1u);
+    array[pos] = (*iter);
+    ++iter;
+    iter = reorder_data(iter, (pos << 1u) + 2u);
+  }
+  return iter;
+}
+
+template<typename T>
+template<typename ForwardIterator>
+EytzingerArray<T>::EytzingerArray(ForwardIterator iter, size_t size) : _size(size) {
+  array = new T[size];
+  reorder_data(iter, 0);
+}
+
+template<typename T>
+template<bool builtin>
+size_t EytzingerArray<T>::search(T x) const {
+  size_t i = 0;
+  while (i < _size) {
+    if (builtin) __builtin_prefetch(array + (multiplier * i + offset));
+    i = (x < array[i]) ? ((i << 1u) + 1u) : ((i << 1u) + 2u);
+  }
+  size_t j = (i + 1u) >> __builtin_ffs(~(i + 1u));
+  return (j == 0) ? _size : j - 1;
+}
+
+template<typename T>
+EytzingerArray<T>::~EytzingerArray() {
+  delete[] array;
+}
+
+#endif //PIECEWISEGEOMETRICMODELINDEX_EYTZINGER_ARRAY_HPP

--- a/include/pgm/eytzinger_array.hpp
+++ b/include/pgm/eytzinger_array.hpp
@@ -89,7 +89,7 @@ template<bool builtin>
 size_t EytzingerArray<T>::search(T x) const {
   size_t i = 0;
   while (i < _size) {
-    if (builtin) __builtin_prefetch(array + (multiplier * i + offset));
+    if constexpr (builtin) __builtin_prefetch(array + (multiplier * i + offset));
     i = (x < array[i]) ? ((i << 1u) + 1u) : ((i << 1u) + 2u);
   }
   size_t j = (i + 1u) >> __builtin_ffs(~(i + 1u));

--- a/include/pgm/pgm_index.hpp
+++ b/include/pgm/pgm_index.hpp
@@ -64,7 +64,7 @@ struct ApproxPos {
 template<typename K, size_t Epsilon = 64, size_t EpsilonRecursive = 4, typename Floating = float>
 class PGMIndex {
 protected:
-    template<typename, size_t, uint8_t, typename>
+    template<typename, size_t, uint8_t, typename, typename>
     friend class BucketingPGMIndex;
 
     template<typename, size_t, typename>

--- a/include/pgm/pgm_index_eytzinger.hpp
+++ b/include/pgm/pgm_index_eytzinger.hpp
@@ -55,6 +55,8 @@ namespace pgm {
  */
 template<typename K, size_t Epsilon = 64, typename Floating = float>
 class PGMIndexEytzinger : public PGMIndex<K, Epsilon, 0, Floating> {
+  template<typename, size_t, uint8_t, typename, typename>
+  friend class BucketingPGMIndex;
 protected:
     struct IndexIterator;
     struct IdxHolder;

--- a/include/pgm/pgm_index_eytzinger.hpp
+++ b/include/pgm/pgm_index_eytzinger.hpp
@@ -54,73 +54,14 @@ namespace pgm {
  * @tparam Floating the floating-point type to use for slopes
  */
 template<typename K, size_t Epsilon = 64, typename Floating = float>
-class PGMIndexEytzinger {
+class PGMIndexEytzinger : public PGMIndex<K, Epsilon, 0, Floating> {
 protected:
-    template<typename, size_t, uint8_t, typename>
-    friend class BucketingPGMIndex;
-
-    template<typename, size_t, typename>
-    friend class EliasFanoPGMIndex;
-
-    static_assert(Epsilon > 0);
-    struct Segment;
     struct IndexIterator;
     struct IdxHolder;
 
-    size_t n;                           ///< The number of elements this index was built on.
-    K first_key;                        ///< The smallest element.
-    std::vector<Segment> segments;      ///< The segments composing the index.
-    std::vector<size_t> levels_offsets; ///< The starting position of each level in segments[], in reverse order.
+    using Segment = typename PGMIndex<K, Epsilon, 0,Floating>::Segment;
+
     EytzingerArray<IdxHolder> eytzinger_first_layer;
-
-    template<typename RandomIt>
-    static void build(RandomIt first, RandomIt last,
-                      size_t epsilon, size_t epsilon_recursive,
-                      std::vector<Segment> &segments,
-                      std::vector<size_t> &levels_offsets) {
-        auto n = (size_t) std::distance(first, last);
-        if (n == 0)
-            return;
-
-        levels_offsets.push_back(0);
-        segments.reserve(n / (epsilon * epsilon));
-
-        auto ignore_last = *std::prev(last) == std::numeric_limits<K>::max(); // max() is the sentinel value
-        auto last_n = n - ignore_last;
-        last -= ignore_last;
-
-        auto build_level = [&](auto epsilon, auto in_fun, auto out_fun) {
-            auto n_segments = internal::make_segmentation_par(last_n, epsilon, in_fun, out_fun);
-            if (segments.back().slope == 0) {
-                // Here we need to ensure that keys > *(last-1) are approximated to a position == prev_level_size
-                segments.emplace_back(*std::prev(last) + 1, 0, last_n);
-                ++n_segments;
-            }
-            segments.emplace_back(last_n); // Add the sentinel segment
-            return n_segments;
-        };
-
-        // Build first level
-        auto in_fun = [&](auto i) {
-            auto x = first[i];
-            // Here there is an adjustment for inputs with duplicate keys: at the end of a run of duplicate keys equal
-            // to x=first[i] such that x+1!=first[i+1], we map the values x+1,...,first[i+1]-1 to their correct rank i
-            auto flag = i > 0 && i + 1u < n && x == first[i - 1] && x != first[i + 1] && x + 1 != first[i + 1];
-            return std::pair<K, size_t>(x + flag, i);
-        };
-        auto out_fun = [&](auto cs) { segments.emplace_back(cs); };
-        last_n = build_level(epsilon, in_fun, out_fun);
-        levels_offsets.push_back(levels_offsets.back() + last_n + 1);
-
-        // Build upper levels
-        while (epsilon_recursive && last_n > 1) {
-            auto offset = levels_offsets[levels_offsets.size() - 2];
-            auto in_fun_rec = [&](auto i) { return std::pair<K, size_t>(segments[offset + i].key, i); };
-            last_n = build_level(epsilon_recursive, in_fun_rec, out_fun);
-            levels_offsets.push_back(levels_offsets.back() + last_n + 1);
-        }
-    }
-
     /**
      * Returns the segment responsible for a given key, that is, the rightmost segment having key <= the sought key.
      * @param key the value of the element to search for
@@ -128,14 +69,11 @@ protected:
      */
     auto segment_for_key(const K &key) const {
       auto idx = eytzinger_first_layer.search(IdxHolder(key, 0));
-      auto it = segments.begin() + ((idx == eytzinger_first_layer.size()) ? segments_count() : eytzinger_first_layer[idx].idx);
-      return it == segments.begin() ? it : std::prev(it);
+      auto it = this->segments.begin() + ((idx == eytzinger_first_layer.size()) ? this->segments_count() : eytzinger_first_layer[idx].idx);
+      return it == this->segments.begin() ? it : std::prev(it);
     }
 
 public:
-
-    static constexpr size_t epsilon_value = Epsilon;
-
     /**
      * Constructs an empty index.
      */
@@ -145,95 +83,27 @@ public:
      * Constructs the index on the given sorted vector.
      * @param data the vector of keys to be indexed, must be sorted
      */
-    explicit PGMIndexEytzinger(const std::vector<K> &data) : PGMIndexEytzinger(data.begin(), data.end()) {}
+    explicit PGMIndexEytzinger(const std::vector<K> &data) : PGMIndex<K, Epsilon, 0, Floating>(data.begin(), data.end()) {}
 
     /**
      * Constructs the index on the sorted keys in the range [first, last).
      * @param first, last the range containing the sorted keys to be indexed
      */
     template<typename RandomIt>
-    PGMIndexEytzinger(RandomIt first, RandomIt last)
-        : n(std::distance(first, last)), eytzinger_first_layer(),
-          first_key(n ? *first : 0),
-          segments(),
-          levels_offsets() {
-        build(first, last, Epsilon, 0, segments, levels_offsets);
-        auto iter = IndexIterator(segments.begin());
-        eytzinger_first_layer = EytzingerArray<IdxHolder>(iter, segments_count());
+    PGMIndexEytzinger(RandomIt first, RandomIt last) :
+        PGMIndex<K, Epsilon, 0, Floating>(first, last), eytzinger_first_layer() {
+        auto iter = IndexIterator(this->segments.begin());
+        eytzinger_first_layer = EytzingerArray<IdxHolder>(iter, this->segments_count());
     }
-
-    /**
-     * Returns the approximate position and the range where @p key can be found.
-     * @param key the value of the element to search for
-     * @return a struct with the approximate position and bounds of the range
-     */
-    ApproxPos search(const K &key) const {
-        auto k = std::max(first_key, key);
-        auto it = segment_for_key(k);
-        auto pos = std::min<size_t>((*it)(k), std::next(it)->intercept);
-        auto lo = PGM_SUB_EPS(pos, Epsilon);
-        auto hi = PGM_ADD_EPS(pos, Epsilon, n);
-        return {pos, lo, hi};
-    }
-
-    /**
-     * Returns the number of segments in the last level of the index.
-     * @return the number of segments
-     */
-    size_t segments_count() const { return segments.empty() ? 0 : levels_offsets[1] - 1; }
-
-    /**
-     * Returns the number of levels of the index.
-     * @return the number of levels of the index
-     */
-    size_t height() const { return levels_offsets.size() - 1; }
 
     /**
      * Returns the size of the index in bytes.
      * @return the size of the index in bytes
      */
-    size_t size_in_bytes() const { return segments.size() * sizeof(Segment) + levels_offsets.size() * sizeof(size_t); }
+    size_t size_in_bytes() const { return this->segments.size() * sizeof(Segment) + this->levels_offsets.size() * sizeof(size_t) + eytzinger_first_layer.size() * sizeof(IdxHolder); }
 };
 
 #pragma pack(push, 1)
-
-template<typename K, size_t Epsilon, typename Floating>
-struct PGMIndexEytzinger<K, Epsilon, Floating>::Segment {
-    K key;             ///< The first key that the segment indexes.
-    Floating slope;    ///< The slope of the segment.
-    int32_t intercept; ///< The intercept of the segment.
-
-    Segment() = default;
-
-    Segment(K key, Floating slope, int32_t intercept) : key(key), slope(slope), intercept(intercept) {};
-
-    explicit Segment(size_t n) : key(std::numeric_limits<K>::max()), slope(), intercept(n) {};
-
-    explicit Segment(const typename internal::OptimalPiecewiseLinearModel<K, size_t>::CanonicalSegment &cs)
-        : key(cs.get_first_x()) {
-        auto[cs_slope, cs_intercept] = cs.get_floating_point_segment(key);
-        if (cs_intercept > std::numeric_limits<decltype(intercept)>::max())
-            throw std::overflow_error("Change the type of Segment::intercept to int64");
-        slope = cs_slope;
-        intercept = cs_intercept;
-    }
-
-    friend inline bool operator<(const Segment &s, const K &k) { return s.key < k; }
-    friend inline bool operator<(const K &k, const Segment &s) { return k < s.key; }
-    friend inline bool operator<(const Segment &s, const Segment &t) { return s.key < t.key; }
-
-    operator K() { return key; };
-
-    /**
-     * Returns the approximate position of the specified key.
-     * @param k the key whose position must be approximated
-     * @return the approximate position of the specified key
-     */
-    inline size_t operator()(const K &k) const {
-        auto pos = int64_t(slope * (k - key)) + intercept;
-        return pos > 0 ? size_t(pos) : 0ull;
-    }
-};
 
 template<typename K, size_t Epsilon, typename Floating>
 struct PGMIndexEytzinger<K, Epsilon, Floating>::IndexIterator {

--- a/include/pgm/pgm_index_variants.hpp
+++ b/include/pgm/pgm_index_variants.hpp
@@ -18,6 +18,7 @@
 #include "morton_nd.hpp"
 #include "piecewise_linear_model.hpp"
 #include "pgm_index.hpp"
+#include "pgm_index_eytzinger.hpp"
 #include "sdsl.hpp"
 
 #include <fcntl.h>

--- a/include/pgm/pgm_index_variants.hpp
+++ b/include/pgm/pgm_index_variants.hpp
@@ -58,6 +58,9 @@ namespace pgm {
 template<typename K, size_t Epsilon, typename Floating = float>
 using OneLevelPGMIndex = PGMIndex<K, Epsilon, 0, Floating>;
 
+template<typename K, size_t Epsilon, typename Floating = float>
+using OneLevelEytzingerPGMIndex = PGMIndexEytzinger<K, Epsilon, Floating>;
+
 /**
  * A variant of @ref PGMIndex that uses compression on the segments to reduce the space of the index.
  *
@@ -370,13 +373,13 @@ struct CompressedPGMIndex<K, Epsilon, EpsilonRecursive, Floating>::CompressedLev
  * @tparam TopLevelBitSize the bit-size of the cells in the top-level table, must be either 0 or a power of two
  * @tparam Floating the floating-point type to use for slopes
  */
-template<typename K, size_t Epsilon = 64, uint8_t TopLevelBitSize = 32, typename Floating = float>
+template<typename K, size_t Epsilon = 64, uint8_t TopLevelBitSize = 32, typename Floating = float, typename PGMType = PGMIndex<K, Epsilon, 0, Floating>>
 class BucketingPGMIndex {
 protected:
     static_assert(Epsilon > 0);
     static_assert(TopLevelBitSize == 0 || (TopLevelBitSize & (TopLevelBitSize - 1u)) == 0);
 
-    using Segment = typename PGMIndex<K, Epsilon, 0, Floating>::Segment;
+    using Segment = typename PGMType::Segment;
 
     size_t n;                                     ///< The number of elements this index was built on.
     K first_key;                                  ///< The smallest element.
@@ -512,6 +515,9 @@ public:
         return segments.size() * sizeof(Segment) + top_level.size() * top_level.width() / CHAR_BIT;
     }
 };
+
+template<typename K, size_t Epsilon = 64, uint8_t TopLevelBitSize = 32, typename Floating = float>
+using BucketingPGMIndexEytzinger = BucketingPGMIndex<K, Epsilon, TopLevelBitSize, Floating, PGMIndexEytzinger<K, Epsilon, Floating>>;
 
 /**
  * A variant of @ref OneLevelPGMIndex that builds a top-level succinct structure to speed up the search on the

--- a/include/pgm/pgm_index_variants.hpp
+++ b/include/pgm/pgm_index_variants.hpp
@@ -395,8 +395,7 @@ protected:
                     " is too low. Try to set it to " + std::to_string(TopLevelBitSize << 1));
             top_level = sdsl::int_vector<TopLevelBitSize>(top_level_size, segments.size(), TopLevelBitSize);
         }
-
-        step = CEIL_INT_DIV(*std::prev(last), top_level_size);
+        step = std::max<K>(CEIL_INT_DIV(*std::prev(last), top_level_size), K(1));
         for (auto i = 0ull, k = 1ull; i < top_level_size - 1; ++i) {
             while (k < segments.size() && (segments[k].key - first_key) < K(i + 1) * step)
                 ++k;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -106,6 +106,14 @@ TEMPLATE_TEST_CASE_SIG("Bucketing PGM-index", "", ((size_t E), E), 8, 32, 128) {
     test_index(index, data);
 }
 
+TEMPLATE_TEST_CASE_SIG("Bucketing PGM-index simple", "", ((size_t E), E), 8, 32, 128) {
+  auto data = std::vector<uint32_t>();
+  data.resize(3000000);
+  auto top_level_size = GENERATE(256, 1024, 4096);
+  pgm::BucketingPGMIndex<uint32_t, E> index(data.begin(), data.end(), top_level_size);
+  test_index(index, data);
+}
+
 TEMPLATE_TEST_CASE_SIG("Elias-Fano PGM-index", "", ((size_t E), E), 8, 32, 128) {
     auto data = generate_data<uint32_t>(3000000);
     pgm::EliasFanoPGMIndex<uint32_t, E> index(data.begin(), data.end());


### PR DESCRIPTION
Since this structure implies the presence of binary search between levels, we thought that we could replace a regular array with one that is optimized for cache queries, accordingly, this speeds up binary search. Accordingly, we also added types for a single-level PGM and a BPGM with this optimization. In this version, we store both arrays, since after transferring the data over them, it is impossible to iterate in the desired order.