### PR TITLE
fixed crash on indexing PGM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-18.04]
+        os: [macos-12, ubuntu-18.04]
         compiler: [gcc, clang]
 
     steps:

--- a/include/pgm/pgm_index.hpp
+++ b/include/pgm/pgm_index.hpp
@@ -96,7 +96,7 @@ protected:
 
         auto build_level = [&](auto epsilon, auto in_fun, auto out_fun) {
             auto n_segments = internal::make_segmentation_par(last_n, epsilon, in_fun, out_fun);
-            if (segments.back().slope == 0 && last_n > 1) {
+            if (last_n > 1 && segments.back().slope == 0) {
                 // Here we need to ensure that keys > *(last-1) are approximated to a position == prev_level_size
                 segments.emplace_back(*std::prev(last) + 1, 0, last_n);
                 ++n_segments;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -274,3 +274,11 @@ TEMPLATE_TEST_CASE_SIG("Multidimensional PGM-index", "",
 }
 
 #endif
+
+TEST_CASE("PGM-index out of bonds", "[tmg]")
+{
+    std::vector<uint32_t> data { std::numeric_limits<uint32_t>::max() };
+    
+    pgm::PGMIndex<uint32_t> index(data.begin(), data.end());
+    REQUIRE ( index.segments_count()==0 );
+}


### PR DESCRIPTION
I've just fixed crash on build PGM index with short vector with only one large value

Seems similar issue was already fixed at #23 however not all cases got covered. I've just refactored that fix to cover more cases.

I also added test case named `PGM-index out of bonds` to `tests` that crashes on building PGM index prior to fix and passed well after fix.