### PR TITLE
Support special case of creating PGM index for only one input element

### DIFF
--- a/include/pgm/piecewise_linear_model.hpp
+++ b/include/pgm/piecewise_linear_model.hpp
@@ -303,7 +303,7 @@ size_t make_segmentation(size_t n, size_t start, size_t end, size_t epsilon, Fin
             add_point(in(i), i);
         }
     }
-    if (end >= 2 && in(end - 1) != in(end - 2))
+    if (end >= start + 2 && in(end - 1) != in(end - 2))
         add_point(in(end - 1), end - 1);
 
     if (end == n) {

--- a/include/pgm/piecewise_linear_model.hpp
+++ b/include/pgm/piecewise_linear_model.hpp
@@ -303,7 +303,7 @@ size_t make_segmentation(size_t n, size_t start, size_t end, size_t epsilon, Fin
             add_point(in(i), i);
         }
     }
-    if (in(end - 1) != in(end - 2))
+    if (end >= 2 && in(end - 1) != in(end - 2))
         add_point(in(end - 1), end - 1);
 
     if (end == n) {


### PR DESCRIPTION
Support special case of creating PGM index for only one input element

Update piecewise_linear_model.hpp

Fix #61

Fix existing bugs:
* If `start = 0, end = 1`,  we will get `end - 2 == size_t(-1)`, which will cause heap-buffer-overflow when we call `in(end - 2)`.
* If `start = 0, end = 1`, then we have `start == end - 1`. We should not call `add_point()` twice for the first element.